### PR TITLE
Add line between ## heading and dropbox link to allow github to render

### DIFF
--- a/devdocs/sprints/README.md
+++ b/devdocs/sprints/README.md
@@ -2,84 +2,105 @@
 
 <hr>
 ## `Latest-Weekly-Update`
+
 ![Latest-Weekly-Update](https://dl.dropbox.com/s/o8mgto0vr8ph0u2/Weekly-Update-2017-09-18.png)
 
 <hr>
 ## `Mini-Sprint-Kickoff-Overview`
+
 ![Mini-Sprint-Kickoff-Overview](https://dl.dropbox.com/s/ad84e5pryz1lrat/mini-sprint-kickoff-overview.png)
 
 <hr>
 ## `Daily-Update-2017-01-11`
+
 ![Daily-Update-2017-01-11](https://dl.dropbox.com/s/ut1d1c2qt1c2czv/daily-update-2017-01-11.png)
 
 <hr>  
 ## `Daily-Update-2017-01-12`
+
 ![Daily-Update-2017-01-12](https://dl.dropbox.com/s/7ouixktxsvf4g7r/daily-update-2017-01-12.png)
 
 <hr>
 ## `Daily-Update-2017-01-13`
+
 ![Daily-Update-2017-01-13](https://dl.dropbox.com/s/i9tlsh4bhacg10y/daily-update-2017-01-13.png)
 
 <hr>
 ## `Daily-Update-2017-01-16`
+
 ![Daily-Update-2017-01-16](https://dl.dropbox.com/s/mis8ran05dbn3ri/daily-update-2017-01-16.png)
 
 <hr>
 ## `Daily-Update-2017-01-17`
+
 ![Daily-Update-2017-01-17](https://dl.dropbox.com/s/zui745cqvjwq7jg/daily-update-2017-01-17.png)
 
 <hr>
 ## `Daily-Update-2017-01-18`
+
 ![Daily-Update-2017-01-18](https://dl.dropbox.com/s/o9oxdu2cfu05veh/daily-update-2017-01-18.png)
 
 <hr>
 ## `Daily-Update-2017-01-19`
+
 ![Daily-Update-2017-01-19](https://dl.dropbox.com/s/qd6jemd34pfezh0/daily-update-2017-01-19.png)
 
 <hr>
 ## `Daily-Update-2017-01-20`
+
 ![Daily-Update-2017-01-20](https://dl.dropbox.com/s/drwmb6sz1ezawjr/daily-update-2017-01-20.png)
 
 <hr>
 ## `Daily-Update-2017-01-23`
+
 ![Daily-Update-2017-01-23](https://dl.dropbox.com/s/8sshz7nce0c0psj/daily-update-2017-01-23.png)
 
 <hr>
 ## `Daily-Update-2017-01-24`
+
 ![Daily-Update-2017-01-24](https://dl.dropbox.com/s/fn00z4jn7j6sxtn/daily-update-2017-01-24.png)
 
 <hr>
 ## `Daily-Update-2017-01-25`
+
 ![Daily-Update-2017-01-25](https://dl.dropbox.com/s/n7o30jvvah8hqx0/daily-update-2017-01-25.png)
 
 <hr>
 ## `Daily-Update-2017-01-26`
+
 ![Daily-Update-2017-01-26](https://dl.dropbox.com/s/bvpxwcnvkh6waw4/daily-update-2017-01-26.png)
 
 <hr>
 ## `Daily-Update-2017-01-28`
+
 ![Daily-Update-2017-01-28](https://dl.dropbox.com/s/43viqrixgse70k0/daily-update-2017-01-28.png)
 
 <hr>
 ## `Daily-Update-2017-01-30`
+
 ![Daily-Update-2017-01-30](https://dl.dropbox.com/s/e36226ug660nq39/Daily-Update-2017-01-30.png)
 
 <hr>
 ## `Daily-Update-2017-02-03`
+
 ![Daily-Update-2017-02-03](https://dl.dropbox.com/s/kizcmbdjcfa8qld/Daily-Update-2017-02-03.png)
 
 <hr>
 ## `Daily-Update-2017-02-05`
+
 ![Daily-Update-2017-02-05](https://dl.dropbox.com/s/u0ffuezt0ez915b/Daily-Update-2017-02-05.png)
 
 <hr>
 ## `Daily-Update-2017-02-08`
+
 ![Daily-Update-2017-02-08](https://dl.dropbox.com/s/bdjsil550r1qktz/Daily-Update-2017-02-08.png)
 
 <hr>
 ## `Daily-Update-2017-04-21`
+
 ![Daily-Update-2017-04-21](https://dl.dropbox.com/s/hm4n1wruq93po02/Daily-Update-2017-04-21.png)
 
 <hr>
 ## `Weekly-Update-2017-09-18`
+
 ![Weekly-Update-2017-09-18](https://dl.dropbox.com/s/o8mgto0vr8ph0u2/Weekly-Update-2017-09-18.png)

--- a/devdocs/sprints/README.md
+++ b/devdocs/sprints/README.md
@@ -1,106 +1,127 @@
 # PhoenixOne Update Documentation
 
 <hr>
+
 ## `Latest-Weekly-Update`
 
 ![Latest-Weekly-Update](https://dl.dropbox.com/s/o8mgto0vr8ph0u2/Weekly-Update-2017-09-18.png)
-
+<br>
 <hr>
+
 ## `Mini-Sprint-Kickoff-Overview`
 
 ![Mini-Sprint-Kickoff-Overview](https://dl.dropbox.com/s/ad84e5pryz1lrat/mini-sprint-kickoff-overview.png)
-
+<br>
 <hr>
+
 ## `Daily-Update-2017-01-11`
 
 ![Daily-Update-2017-01-11](https://dl.dropbox.com/s/ut1d1c2qt1c2czv/daily-update-2017-01-11.png)
-
+<br>
 <hr>  
+
 ## `Daily-Update-2017-01-12`
 
 ![Daily-Update-2017-01-12](https://dl.dropbox.com/s/7ouixktxsvf4g7r/daily-update-2017-01-12.png)
-
+<br>
 <hr>
+
 ## `Daily-Update-2017-01-13`
 
 ![Daily-Update-2017-01-13](https://dl.dropbox.com/s/i9tlsh4bhacg10y/daily-update-2017-01-13.png)
-
+<br>
 <hr>
+
 ## `Daily-Update-2017-01-16`
 
 ![Daily-Update-2017-01-16](https://dl.dropbox.com/s/mis8ran05dbn3ri/daily-update-2017-01-16.png)
-
+<br>
 <hr>
+
 ## `Daily-Update-2017-01-17`
 
 ![Daily-Update-2017-01-17](https://dl.dropbox.com/s/zui745cqvjwq7jg/daily-update-2017-01-17.png)
-
+<br>
 <hr>
+
 ## `Daily-Update-2017-01-18`
 
 ![Daily-Update-2017-01-18](https://dl.dropbox.com/s/o9oxdu2cfu05veh/daily-update-2017-01-18.png)
-
+<br>
 <hr>
+
 ## `Daily-Update-2017-01-19`
 
 ![Daily-Update-2017-01-19](https://dl.dropbox.com/s/qd6jemd34pfezh0/daily-update-2017-01-19.png)
-
+<br>
 <hr>
+
 ## `Daily-Update-2017-01-20`
 
 ![Daily-Update-2017-01-20](https://dl.dropbox.com/s/drwmb6sz1ezawjr/daily-update-2017-01-20.png)
-
+<br>
 <hr>
+
 ## `Daily-Update-2017-01-23`
 
 ![Daily-Update-2017-01-23](https://dl.dropbox.com/s/8sshz7nce0c0psj/daily-update-2017-01-23.png)
-
+<br>
 <hr>
+
 ## `Daily-Update-2017-01-24`
 
 ![Daily-Update-2017-01-24](https://dl.dropbox.com/s/fn00z4jn7j6sxtn/daily-update-2017-01-24.png)
-
+<br>
 <hr>
+
 ## `Daily-Update-2017-01-25`
 
 ![Daily-Update-2017-01-25](https://dl.dropbox.com/s/n7o30jvvah8hqx0/daily-update-2017-01-25.png)
-
+<br>
 <hr>
+
 ## `Daily-Update-2017-01-26`
 
 ![Daily-Update-2017-01-26](https://dl.dropbox.com/s/bvpxwcnvkh6waw4/daily-update-2017-01-26.png)
-
+<br>
 <hr>
+
 ## `Daily-Update-2017-01-28`
 
 ![Daily-Update-2017-01-28](https://dl.dropbox.com/s/43viqrixgse70k0/daily-update-2017-01-28.png)
-
+<br>
 <hr>
+
 ## `Daily-Update-2017-01-30`
 
 ![Daily-Update-2017-01-30](https://dl.dropbox.com/s/e36226ug660nq39/Daily-Update-2017-01-30.png)
-
+<br>
 <hr>
+
 ## `Daily-Update-2017-02-03`
 
 ![Daily-Update-2017-02-03](https://dl.dropbox.com/s/kizcmbdjcfa8qld/Daily-Update-2017-02-03.png)
-
+<br>
 <hr>
+
 ## `Daily-Update-2017-02-05`
 
 ![Daily-Update-2017-02-05](https://dl.dropbox.com/s/u0ffuezt0ez915b/Daily-Update-2017-02-05.png)
-
+<br>
 <hr>
+
 ## `Daily-Update-2017-02-08`
 
 ![Daily-Update-2017-02-08](https://dl.dropbox.com/s/bdjsil550r1qktz/Daily-Update-2017-02-08.png)
-
+<br>
 <hr>
+
 ## `Daily-Update-2017-04-21`
 
 ![Daily-Update-2017-04-21](https://dl.dropbox.com/s/hm4n1wruq93po02/Daily-Update-2017-04-21.png)
-
+<br>
 <hr>
+
 ## `Weekly-Update-2017-09-18`
 
 ![Weekly-Update-2017-09-18](https://dl.dropbox.com/s/o8mgto0vr8ph0u2/Weekly-Update-2017-09-18.png)


### PR DESCRIPTION
Github's markdown changes, this year, had broken the rendering of dropbox image links.